### PR TITLE
Add: 枠線と文字だけのアウトラインボタンコンポーネントを追加しました

### DIFF
--- a/components/atoms/outline-button/OutlineButton.css
+++ b/components/atoms/outline-button/OutlineButton.css
@@ -1,0 +1,20 @@
+button {
+    font-size: 2rem;
+    font-family: Arial, sans-serif;
+    font-weight: bold;
+    color: #fff;
+    padding: 0.25rem 2rem;
+    background: transparent;
+    border: 0.2rem solid #fff;
+    border-radius: 2rem;
+
+    cursor: pointer;
+}
+
+button:hover {
+  background: #a3835d;
+}
+
+button:active {
+  transform: scale(0.95);
+}

--- a/components/atoms/outline-button/page.tsx
+++ b/components/atoms/outline-button/page.tsx
@@ -1,0 +1,10 @@
+import './OutlineButton.css';
+
+type Props = {
+    label: string;
+    onClick: () => void;
+};
+
+export function OutlineButtton ({label, onClick}: Props) {
+    return <button onClick={onClick}>{label}</button>
+}


### PR DESCRIPTION
前回の白ボタンの色違いです。
<img width="241" height="154" alt="スクリーンショット 2025-12-11 170257" src="https://github.com/user-attachments/assets/703f0914-0eb4-4ca2-ae04-502fdaa6c107" />
