### PR TITLE
バックエンドと接続するための設定の変更

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ export default function Page() {
 
     try { 
       // バックのAPIをたたく
-      const API_BASE_URL = 'https://backend-app.delightfulsand-96b8be6a.japanwest.azurecontainerapps.io';
+      const API_BASE_URL = 'http://localhost:8080';
 
       const respone = await fetch(`${API_BASE_URL}/api/auth/register?username=${encodeURIComponent(userName)}`, {
         method: 'POST',

--- a/hooks/useSocket.tsx
+++ b/hooks/useSocket.tsx
@@ -27,7 +27,7 @@ export const SocketProvider = ({children}: { children: ReactNode}) => {
     // ソケット接続フラグ : コネクションを条件付きで開始するため
     const  [shouldConnect, setShouldConnect] = useState(false);
 
-    const WS_BASE_URL = 'wss://localhost:8080';
+    const WS_BASE_URL = 'ws://localhost:8080';
 
 
     // 接続時に送信するためユーザー名取得

--- a/hooks/useSocket.tsx
+++ b/hooks/useSocket.tsx
@@ -27,7 +27,7 @@ export const SocketProvider = ({children}: { children: ReactNode}) => {
     // ソケット接続フラグ : コネクションを条件付きで開始するため
     const  [shouldConnect, setShouldConnect] = useState(false);
 
-    const WS_BASE_URL = 'wss://backend-app.delightfulsand-96b8be6a.japanwest.azurecontainerapps.io';
+    const WS_BASE_URL = 'wss://localhost:8080';
 
 
     // 接続時に送信するためユーザー名取得


### PR DESCRIPTION
- 接続先をazureからローカルホストに変更
- WebSocketのURLをwssからwsに変更
  - 理由: 元々のエンドポイントがhttpでセキュア接続でないため